### PR TITLE
rtorrent: Replace deprecated rtorrent commands.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-  - 1.6
+  - "1.12"
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
 before_script:
   - go get -d ./...
 script:

--- a/downloads.go
+++ b/downloads.go
@@ -58,17 +58,17 @@ func (s *DownloadService) Active() ([]string, error) {
 // BaseFilename retrieves the base filename shown in the rTorrent UI for a
 // specific download, by its info-hash.
 func (s *DownloadService) BaseFilename(infoHash string) (string, error) {
-	return s.c.getString("d.get_base_filename", infoHash)
+	return s.c.getString("d.base_filename", infoHash)
 }
 
 // DownloadRate retrieves the current download rate in bytes for a specific
 // download, by its info-hash.
 func (s *DownloadService) DownloadRate(infoHash string) (int, error) {
-	return s.c.getInt("d.get_down_rate", infoHash)
+	return s.c.getInt("d.down.rate", infoHash)
 }
 
 // UploadRate retrieves the current upload rate in bytes for a specific
 // download, by its info-hash.
 func (s *DownloadService) UploadRate(infoHash string) (int, error) {
-	return s.c.getInt("d.get_up_rate", infoHash)
+	return s.c.getInt("d.up.rate", infoHash)
 }

--- a/downloads_test.go
+++ b/downloads_test.go
@@ -184,7 +184,7 @@ func TestClientDownloadsBaseFilename(t *testing.T) {
 	wantName := "foobar"
 	wantHash := strings.Repeat("A", 40)
 
-	c, done := testClient(t, "d.get_base_filename", []string{wantHash}, wantName)
+	c, done := testClient(t, "d.base_filename", []string{wantHash}, wantName)
 	defer done()
 
 	name, err := c.Downloads.BaseFilename(wantHash)
@@ -202,7 +202,7 @@ func TestClientDownloadsDownloadRate(t *testing.T) {
 	wantRate := 1024
 	wantHash := strings.Repeat("A", 40)
 
-	c, done := testClient(t, "d.get_down_rate", []string{wantHash}, wantRate)
+	c, done := testClient(t, "d.down.rate", []string{wantHash}, wantRate)
 	defer done()
 
 	rate, err := c.Downloads.DownloadRate(wantHash)
@@ -220,7 +220,7 @@ func TestClientDownloadsUploadRate(t *testing.T) {
 	wantRate := 1024
 	wantHash := strings.Repeat("A", 40)
 
-	c, done := testClient(t, "d.get_up_rate", []string{wantHash}, wantRate)
+	c, done := testClient(t, "d.up.rate", []string{wantHash}, wantRate)
 	defer done()
 
 	rate, err := c.Downloads.UploadRate(wantHash)

--- a/rtorrent.go
+++ b/rtorrent.go
@@ -40,23 +40,23 @@ func (c *Client) Close() error {
 // DownloadTotal retrieves the total number of downloaded bytes since
 // rTorrent startup.
 func (c *Client) DownloadTotal() (int, error) {
-	return c.getInt("get_down_total", "")
+	return c.getInt("down.total", "")
 }
 
 // UploadTotal retrieves the total number of uploaded bytes since
 // rTorrent startup.
 func (c *Client) UploadTotal() (int, error) {
-	return c.getInt("get_up_total", "")
+	return c.getInt("up.total", "")
 }
 
 // DownloadRate retrieves the current download rate in bytes from rTorrent.
 func (c *Client) DownloadRate() (int, error) {
-	return c.getInt("get_down_rate", "")
+	return c.getInt("down.rate", "")
 }
 
 // UploadRate retrieves the current upload rate in bytes from rTorrent.
 func (c *Client) UploadRate() (int, error) {
-	return c.getInt("get_up_rate", "")
+	return c.getInt("up.rate", "")
 }
 
 // getInt retrieves an integer value from the specified XML-RPC method.

--- a/rtorrent_test.go
+++ b/rtorrent_test.go
@@ -13,7 +13,7 @@ import (
 func TestClientDownloadTotal(t *testing.T) {
 	wantTotal := 1024
 
-	c, done := testClient(t, "get_down_total", nil, wantTotal)
+	c, done := testClient(t, "down.total", nil, wantTotal)
 	defer done()
 
 	total, err := c.DownloadTotal()
@@ -30,7 +30,7 @@ func TestClientDownloadTotal(t *testing.T) {
 func TestClientUploadTotal(t *testing.T) {
 	wantTotal := 1024
 
-	c, done := testClient(t, "get_up_total", nil, wantTotal)
+	c, done := testClient(t, "up.total", nil, wantTotal)
 	defer done()
 
 	total, err := c.UploadTotal()
@@ -47,7 +47,7 @@ func TestClientUploadTotal(t *testing.T) {
 func TestClientDownloadRate(t *testing.T) {
 	wantRate := 1024
 
-	c, done := testClient(t, "get_down_rate", nil, wantRate)
+	c, done := testClient(t, "down.rate", nil, wantRate)
 	defer done()
 
 	rate, err := c.DownloadRate()
@@ -64,7 +64,7 @@ func TestClientDownloadRate(t *testing.T) {
 func TestClientUploadRate(t *testing.T) {
 	wantRate := 1024
 
-	c, done := testClient(t, "get_up_rate", nil, wantRate)
+	c, done := testClient(t, "up.rate", nil, wantRate)
 	defer done()
 
 	rate, err := c.UploadRate()


### PR DESCRIPTION
https://github.com/rakshasa/rtorrent/commit/51c5190 deprecated rtorrent commands we were using. This commit replaces them with their successors.

travis.yml file was updated to fix build error.

Fixes mdlayher/rtorrent_exporter#4.